### PR TITLE
Update code to replace string class_eval with the block form

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
-threshold: 18
-total_score: 35
+threshold: 13
+total_score: 25

--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 8.9
+threshold: 18.4

--- a/config/site.reek
+++ b/config/site.reek
@@ -46,7 +46,9 @@ UncommunicativeModuleName:
   - !ruby/regexp /[0-9]$/
 NestedIterators:
   ignore_iterators: []
-  exclude: []
+  exclude: [
+    'AbstractType::ClassMethods#create_abstract_singleton_method'
+  ]
   enabled: true
   max_allowed_nesting: 1
 LongMethod:

--- a/lib/abstract_type.rb
+++ b/lib/abstract_type.rb
@@ -90,11 +90,11 @@ module AbstractType
     #
     # @api private
     def create_abstract_singleton_method(name)
-      class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def self.#{name}(*)                                                    # def self.name(*)
-          raise NotImplementedError, "\#{inspect}.#{name} is not implemented"  #   raise NotImplementedError, '\#{inspect}.name is not implemented'
-        end                                                                    # end
-      RUBY
+      singleton_class.class_eval do
+        define_method(name) do
+          raise NotImplementedError, "#{inspect}.#{name} is not implemented"
+        end
+      end
     end
 
     # Create abstract instance method
@@ -106,11 +106,9 @@ module AbstractType
     #
     # @api private
     def create_abstract_instance_method(name)
-      class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{name}(*)                                                                    # def name(*)
-          raise NotImplementedError, "\#{self.class.inspect}##{name} is not implemented"  #   raise NotImplementedError, "\#{self.class.inspect}#name is not implemented"
-        end                                                                               # end
-      RUBY
+      define_method(name) do
+        raise NotImplementedError, "#{self.class.inspect}##{name} is not implemented"
+      end
     end
 
   end # module ClassMethods

--- a/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
+++ b/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
@@ -32,7 +32,7 @@ describe AbstractType::ClassMethods, '#abstract_method' do
       error.message.should == 'Subclass#some_method is not implemented'
       file, line = error.backtrace.first.split(':', 2)
       File.expand_path(file).should eql(File.expand_path('../../../../../lib/abstract_type.rb', __FILE__))
-      line.to_i.should be(111)
+      line.to_i.should be(110)
     else
       raise 'expected error not raised'
     end

--- a/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
+++ b/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
@@ -30,9 +30,8 @@ describe AbstractType::ClassMethods, '#abstract_method' do
       subclass.new.some_method
     rescue NotImplementedError => error
       error.message.should == 'Subclass#some_method is not implemented'
-      file, line = error.backtrace.first.split(':', 2)
+      file = error.backtrace.first.split(':').first
       File.expand_path(file).should eql(File.expand_path('../../../../../lib/abstract_type.rb', __FILE__))
-      line.to_i.should be(110)
     else
       raise 'expected error not raised'
     end

--- a/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
+++ b/spec/unit/abstract_type/class_methods/abstract_method_spec.rb
@@ -24,24 +24,8 @@ describe AbstractType::ClassMethods, '#abstract_method' do
       to(true)
   end
 
-  specification = proc do
+  it 'creates a method that raises an exception' do
     subject
-    begin
-      subclass.new.some_method
-    rescue NotImplementedError => error
-      error.message.should == 'Subclass#some_method is not implemented'
-      file = error.backtrace.first.split(':').first
-      File.expand_path(file).should eql(File.expand_path('../../../../../lib/abstract_type.rb', __FILE__))
-    else
-      raise 'expected error not raised'
-    end
-  end
-
-  it 'sets the file and line number properly' do
-    if RUBY_PLATFORM.include?('java')
-      pending('Kernel#caller returns the incorrect line number in JRuby', &specification)
-    else
-      instance_eval(&specification)
-    end
+    expect { subclass.new.some_method }.to raise_error(NotImplementedError, 'Subclass#some_method is not implemented')
   end
 end

--- a/spec/unit/abstract_type/class_methods/abstract_singleton_method_spec.rb
+++ b/spec/unit/abstract_type/class_methods/abstract_singleton_method_spec.rb
@@ -24,24 +24,8 @@ describe AbstractType::ClassMethods, '#abstract_singleton_method' do
       to(true)
   end
 
-  specification = proc do
+  it 'creates a method that raises an exception' do
     subject
-    begin
-      subclass.some_method
-    rescue NotImplementedError => error
-      error.message.should == 'Subclass.some_method is not implemented'
-      file = error.backtrace.first.split(':').first
-      File.expand_path(file).should eql(File.expand_path('../../../../../lib/abstract_type.rb', __FILE__))
-    else
-      raise 'expected error not raised'
-    end
-  end
-
-  it 'sets the file and line number properly' do
-    if RUBY_PLATFORM.include?('java')
-      pending('Kernel#caller returns the incorrect line number in JRuby', &specification)
-    else
-      instance_eval(&specification)
-    end
+    expect { subclass.some_method }.to raise_error(NotImplementedError, 'Subclass.some_method is not implemented')
   end
 end

--- a/spec/unit/abstract_type/class_methods/abstract_singleton_method_spec.rb
+++ b/spec/unit/abstract_type/class_methods/abstract_singleton_method_spec.rb
@@ -30,9 +30,8 @@ describe AbstractType::ClassMethods, '#abstract_singleton_method' do
       subclass.some_method
     rescue NotImplementedError => error
       error.message.should == 'Subclass.some_method is not implemented'
-      file, line = error.backtrace.first.split(':', 2)
+      file = error.backtrace.first.split(':').first
       File.expand_path(file).should eql(File.expand_path('../../../../../lib/abstract_type.rb', __FILE__))
-      line.to_i.should be(95)
     else
       raise 'expected error not raised'
     end


### PR DESCRIPTION
This branch replaces string class_eval with the block form. Some metrics needed to be bumped up, but I'm fine with that since the string class_eval was hiding some of the complexity of the methods.
